### PR TITLE
Fix/android namespace requirement

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.maru.twitter_login'
     compileSdkVersion 31
 
     compileOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: twitter_login
 description: Flutter Twitter Login Plugin. Library for login with Twitter APIs OAuth service
 
-version: 4.4.2
+version: 4.4.3
 
 homepage: https://twitter.com/0maru_dev
 repository: https://github.com/0maru/twitter_login


### PR DESCRIPTION
- Fixes a build issue that requires Android to require namespaces within build.gradle

- Bumped fix version to 4.4.3 (from 4.4.2)